### PR TITLE
Feat: Regeneration Restriction

### DIFF
--- a/client/TODO.md
+++ b/client/TODO.md
@@ -6,9 +6,10 @@
 - [ ] Connect state for `face-off` and `face-off-result` so that a transition between components doesn't need to happen
 - [ ] Protect game pages from players who are not a part of it
 - [ ] Optional user auth
-- [ ] Add donate button
 
 ## In Progress
+
+- [ ] Maximum on amount of regenerations (3 per game?)
 
 ## Done ✓
 
@@ -26,3 +27,4 @@
 - [x] Safari title font kerning bug
 - [x] Change image generator endpoint to use `openai-edge`
 - [x] How-to-play screen
+- [x] Add donate button

--- a/client/src/app/server-actions.ts
+++ b/client/src/app/server-actions.ts
@@ -30,6 +30,7 @@ export type Generation = {
   imageUrl: string;
   userId: number;
   questionId: number;
+  gameId: number;
   createdAt: string;
 };
 export type Question = {

--- a/client/src/app/server-actions.ts
+++ b/client/src/app/server-actions.ts
@@ -173,6 +173,57 @@ export async function getLeaderboardById({ gameId }: { gameId: number }) {
   return data;
 }
 
+export type GetRegenerationCountResponse = { count: number };
+
+export async function getRegenerationCount({
+  gameId,
+  userId,
+}: {
+  gameId: number;
+  userId: number;
+}) {
+  const response = await fetch(
+    `${URL}/game/${gameId}/regenerations/${userId}`,
+    {
+      cache: "no-store",
+    }
+  );
+
+  const data: GetRegenerationCountResponse = await response.json();
+
+  return data;
+}
+
+export type incrementUserRegenerationCountResponse = {
+  room: Room;
+};
+
+export async function incrementUserRegenerationCount({
+  gameId,
+  userId,
+}: {
+  gameId: number;
+  userId: number;
+}) {
+  const response = await fetch(
+    `${URL}/game/${gameId}/regenerations/${userId}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        userId,
+        gameId,
+      }),
+    }
+  );
+
+  const data: incrementUserRegenerationCountResponse = await response.json();
+
+  return data;
+}
+
 // ! ----------> GENERATIONS <----------
 
 export type GetFaceOffsResponse = QuestionGenerations[];

--- a/client/src/components/game/prompt.tsx
+++ b/client/src/components/game/prompt.tsx
@@ -91,7 +91,7 @@ const Prompt = ({
     });
   }, [currRound, gameInfo.questions, user?.id]);
 
-  // State machine to handle the two questions of the current round
+  // State to handle the two questions of the current round
   const [stage, setStage] = useState<"FIRST" | "SECOND">("FIRST");
 
   const currQuestion = stage === "FIRST" ? questions[0] : questions[1];
@@ -172,9 +172,11 @@ const Prompt = ({
 
     if (stage === "FIRST") {
       setStage("SECOND");
-      setImagePrompt("");
       resetImageAndPrompt();
     } else {
+      window.localStorage.removeItem("prompt");
+      window.localStorage.removeItem("image1");
+      window.localStorage.removeItem("image2");
       send({ type: "SUBMIT" });
     }
 

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -110,6 +110,7 @@ export const usersToGames = pgTable(
       .references(() => games.id)
       .notNull(),
     points: integer("points").default(0).notNull(),
+    regenerationCount: integer("regeneration_count").default(0).notNull(),
   },
   (table) => ({
     cpk: primaryKey(table.userId, table.gameId),

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -81,6 +81,7 @@ export const generations = pgTable("generations", {
   userId: integer("user_id")
     .references(() => users.id)
     .notNull(),
+  gameId: integer("game_id").references(() => games.id), // TODO make gameId not null
   questionId: integer("question_id")
     .references(() => questions.id)
     .notNull(),

--- a/server/drizzle/0016_violet_electro.sql
+++ b/server/drizzle/0016_violet_electro.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users_to_games" ADD COLUMN "regeneration_count" integer DEFAULT 0 NOT NULL;

--- a/server/drizzle/0017_nostalgic_northstar.sql
+++ b/server/drizzle/0017_nostalgic_northstar.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "generations" ADD COLUMN "game_id" integer;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "generations" ADD CONSTRAINT "generations_game_id_games_id_fk" FOREIGN KEY ("game_id") REFERENCES "games"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/server/drizzle/meta/0016_snapshot.json
+++ b/server/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,556 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "3202feed-f2d9-4372-a48b-d55ece7c1bef",
+  "prevId": "9ca8f46e-bc2c-4fce-9b69-40cef729948d",
+  "tables": {
+    "games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "room_code": {
+          "name": "room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_room_code_rooms_code_fk": {
+          "name": "games_room_code_rooms_code_fk",
+          "tableFrom": "games",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "generations": {
+      "name": "generations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "generations_user_id_users_id_fk": {
+          "name": "generations_user_id_users_id_fk",
+          "tableFrom": "generations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "generations_question_id_questions_id_fk": {
+          "name": "generations_question_id_questions_id_fk",
+          "tableFrom": "generations",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "questions_to_games": {
+      "name": "questions_to_games",
+      "schema": "",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_1": {
+          "name": "player_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_2": {
+          "name": "player_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_to_games_question_id_questions_id_fk": {
+          "name": "questions_to_games_question_id_questions_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "questions_to_games_game_id_games_id_fk": {
+          "name": "questions_to_games_game_id_games_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "questions_to_games_player_1_users_id_fk": {
+          "name": "questions_to_games_player_1_users_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_1"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "questions_to_games_player_2_users_id_fk": {
+          "name": "questions_to_games_player_2_users_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "questions_to_games_game_id_question_id": {
+          "name": "questions_to_games_game_id_question_id",
+          "columns": [
+            "game_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rooms_host_id_users_id_fk": {
+          "name": "rooms_host_id_users_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users_to_games": {
+      "name": "users_to_games",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regeneration_count": {
+          "name": "regeneration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_games_user_id_users_id_fk": {
+          "name": "users_to_games_user_id_users_id_fk",
+          "tableFrom": "users_to_games",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_games_game_id_games_id_fk": {
+          "name": "users_to_games_game_id_games_id_fk",
+          "tableFrom": "users_to_games",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_games_user_id_game_id": {
+          "name": "users_to_games_user_id_game_id",
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "users_to_rooms": {
+      "name": "users_to_rooms",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_code": {
+          "name": "room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_rooms_user_id_users_id_fk": {
+          "name": "users_to_rooms_user_id_users_id_fk",
+          "tableFrom": "users_to_rooms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_rooms_room_code_rooms_code_fk": {
+          "name": "users_to_rooms_room_code_rooms_code_fk",
+          "tableFrom": "users_to_rooms",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_rooms_user_id_room_code": {
+          "name": "users_to_rooms_user_id_room_code",
+          "columns": [
+            "user_id",
+            "room_code"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "votes_generation_id_generations_id_fk": {
+          "name": "votes_generation_id_generations_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "generations",
+          "columnsFrom": [
+            "generation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/server/drizzle/meta/0017_snapshot.json
+++ b/server/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,575 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "9036cd8d-8cc3-49fe-8913-9d2d9aca4b6d",
+  "prevId": "3202feed-f2d9-4372-a48b-d55ece7c1bef",
+  "tables": {
+    "games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "room_code": {
+          "name": "room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_room_code_rooms_code_fk": {
+          "name": "games_room_code_rooms_code_fk",
+          "tableFrom": "games",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "generations": {
+      "name": "generations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "generations_user_id_users_id_fk": {
+          "name": "generations_user_id_users_id_fk",
+          "tableFrom": "generations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "generations_game_id_games_id_fk": {
+          "name": "generations_game_id_games_id_fk",
+          "tableFrom": "generations",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "generations_question_id_questions_id_fk": {
+          "name": "generations_question_id_questions_id_fk",
+          "tableFrom": "generations",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "questions_to_games": {
+      "name": "questions_to_games",
+      "schema": "",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_1": {
+          "name": "player_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_2": {
+          "name": "player_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_to_games_question_id_questions_id_fk": {
+          "name": "questions_to_games_question_id_questions_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "questions_to_games_game_id_games_id_fk": {
+          "name": "questions_to_games_game_id_games_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "questions_to_games_player_1_users_id_fk": {
+          "name": "questions_to_games_player_1_users_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_1"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "questions_to_games_player_2_users_id_fk": {
+          "name": "questions_to_games_player_2_users_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "questions_to_games_game_id_question_id": {
+          "name": "questions_to_games_game_id_question_id",
+          "columns": [
+            "game_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rooms_host_id_users_id_fk": {
+          "name": "rooms_host_id_users_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users_to_games": {
+      "name": "users_to_games",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regeneration_count": {
+          "name": "regeneration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_games_user_id_users_id_fk": {
+          "name": "users_to_games_user_id_users_id_fk",
+          "tableFrom": "users_to_games",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_games_game_id_games_id_fk": {
+          "name": "users_to_games_game_id_games_id_fk",
+          "tableFrom": "users_to_games",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_games_user_id_game_id": {
+          "name": "users_to_games_user_id_game_id",
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "users_to_rooms": {
+      "name": "users_to_rooms",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_code": {
+          "name": "room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_rooms_user_id_users_id_fk": {
+          "name": "users_to_rooms_user_id_users_id_fk",
+          "tableFrom": "users_to_rooms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_rooms_room_code_rooms_code_fk": {
+          "name": "users_to_rooms_room_code_rooms_code_fk",
+          "tableFrom": "users_to_rooms",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_rooms_user_id_room_code": {
+          "name": "users_to_rooms_user_id_room_code",
+          "columns": [
+            "user_id",
+            "room_code"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "votes_generation_id_generations_id_fk": {
+          "name": "votes_generation_id_generations_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "generations",
+          "columnsFrom": [
+            "generation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1691193138475,
       "tag": "0016_violet_electro",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "5",
+      "when": 1691244559328,
+      "tag": "0017_nostalgic_northstar",
+      "breakpoints": true
     }
   ]
 }

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1690287262008,
       "tag": "0015_nifty_earthquake",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "5",
+      "when": 1691193138475,
+      "tag": "0016_violet_electro",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/controllers/game.controller.ts
+++ b/server/src/controllers/game.controller.ts
@@ -2,6 +2,8 @@ import type { NextFunction, Request, Response } from "express";
 import {
   getLeaderboardById,
   getPageGameInfoByRoomCode,
+  getUserRegenerationCount,
+  incrementUserRegenerationCount,
 } from "../services/game.service";
 
 export async function getPageGameInfoByRoomCodeController(
@@ -43,6 +45,60 @@ export async function getLeaderboardByIdController(
     }
 
     res.status(200).send(gameInfo);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getUserRegenerationCountController(
+  req: Request<{ id: string; userId: string }>,
+  res: Response,
+  next: NextFunction
+) {
+  try {
+    const gameId = Number.parseInt(req.params.id);
+    const userId = Number.parseInt(req.params.userId);
+
+    const regenerationCount = await getUserRegenerationCount({
+      gameId,
+      userId,
+    });
+
+    if (regenerationCount === undefined || regenerationCount === null) {
+      res.status(404).send({
+        error: `Regeneration Count with a game id of ${gameId} and a user id of ${userId} was not found`,
+      });
+      return;
+    }
+
+    res.status(200).send({ count: regenerationCount });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function incrementUserRegenerationCountController(
+  req: Request<{ id: string; userId: string }>,
+  res: Response,
+  next: NextFunction
+) {
+  try {
+    const gameId = Number.parseInt(req.params.id);
+    const userId = Number.parseInt(req.params.userId);
+
+    const regenerationCount = await incrementUserRegenerationCount({
+      gameId,
+      userId,
+    });
+
+    if (regenerationCount === undefined || regenerationCount === null) {
+      res.status(404).send({
+        error: `Regeneration Count with a game id of ${gameId} and a user id of ${userId} was not found`,
+      });
+      return;
+    }
+
+    res.status(200).send({ count: regenerationCount });
   } catch (error) {
     next(error);
   }

--- a/server/src/routes/game.route.ts
+++ b/server/src/routes/game.route.ts
@@ -2,9 +2,20 @@ import type { Express } from "express";
 import {
   getLeaderboardByIdController,
   getPageGameInfoByRoomCodeController,
+  getUserRegenerationCountController,
+  incrementUserRegenerationCountController,
 } from "../controllers/game.controller";
 
 export function gameRoutes(app: Express) {
   app.get("/game/:code", getPageGameInfoByRoomCodeController);
   app.get("/game/:id/leaderboard", getLeaderboardByIdController);
+  app.get(
+    "/game/:id/regenerations/:userId",
+    getUserRegenerationCountController
+  );
+
+  app.post(
+    "/game/:id/regenerations/:userId",
+    incrementUserRegenerationCountController
+  );
 }

--- a/server/src/services/game.service.ts
+++ b/server/src/services/game.service.ts
@@ -199,3 +199,39 @@ export async function addUsersToGame({
 
   return usersToGame;
 }
+
+export async function getUserRegenerationCount({
+  gameId,
+  userId,
+}: {
+  gameId: number;
+  userId: number;
+}) {
+  const regenerationCount = await db
+    .select({ count: usersToGames.regenerationCount })
+    .from(usersToGames)
+    .where(
+      and(eq(usersToGames.userId, userId), eq(usersToGames.gameId, gameId))
+    );
+
+  return regenerationCount[0].count;
+}
+
+export async function incrementUserRegenerationCount({
+  gameId,
+  userId,
+}: {
+  gameId: number;
+  userId: number;
+}) {
+  const currentCount = await getUserRegenerationCount({ gameId, userId });
+  const incrementedCount = await db
+    .update(usersToGames)
+    .set({ regenerationCount: currentCount + 1 })
+    .where(
+      and(eq(usersToGames.userId, userId), eq(usersToGames.gameId, gameId))
+    )
+    .returning();
+
+  return incrementedCount[0].regenerationCount;
+}

--- a/server/src/services/generation.service.ts
+++ b/server/src/services/generation.service.ts
@@ -119,6 +119,7 @@ export async function createGeneration(data: NewGeneration) {
     .values({
       imageUrl: data.imageUrl,
       questionId: data.questionId,
+      gameId: data.gameId,
       text: data.text,
       userId: data.userId,
     })

--- a/server/src/services/generation.service.ts
+++ b/server/src/services/generation.service.ts
@@ -34,15 +34,15 @@ export async function getGameRoundGenerations({
     .from(generations)
     .innerJoin(
       questionsToGames,
-      eq(questionsToGames.questionId, generations.questionId)
+      and(
+        eq(questionsToGames.gameId, generations.gameId),
+        eq(questionsToGames.questionId, generations.questionId)
+      )
     )
     .innerJoin(questions, eq(questions.id, generations.questionId))
     .innerJoin(users, eq(users.id, generations.userId))
     .where(
-      and(
-        eq(questionsToGames.gameId, gameId),
-        eq(questionsToGames.round, round)
-      )
+      and(eq(generations.gameId, gameId), eq(questionsToGames.round, round))
     )
     .orderBy(asc(questionsToGames.createdAt), asc(questionsToGames.questionId));
 

--- a/server/src/tests/generation.test.ts
+++ b/server/src/tests/generation.test.ts
@@ -14,6 +14,7 @@ describe("filterGameRoundGenerationsByQuestionId", () => {
           userId: 5,
           text: "A dog eating a burger",
           questionId: 2,
+          gameId: 2,
           imageUrl: "LINK TO IMAGE",
         },
         question: {
@@ -38,6 +39,7 @@ describe("filterGameRoundGenerationsByQuestionId", () => {
           userId: 6,
           text: "A dog eating a salmon",
           questionId: 2,
+          gameId: 2,
           imageUrl: "LINK TO IMAGE",
         },
         question: {
@@ -62,6 +64,7 @@ describe("filterGameRoundGenerationsByQuestionId", () => {
           userId: 7,
           text: "A dog eating a pop tart",
           questionId: 2,
+          gameId: 2,
           imageUrl: "LINK TO IMAGE",
         },
         question: {
@@ -86,6 +89,7 @@ describe("filterGameRoundGenerationsByQuestionId", () => {
           userId: 8,
           text: "A dog eating a hot dog",
           questionId: 2,
+          gameId: 2,
           imageUrl: "LINK TO IMAGE",
         },
         question: {

--- a/server/src/tests/vote.test.ts
+++ b/server/src/tests/vote.test.ts
@@ -41,6 +41,7 @@ describe("createVoteMap", () => {
         userId: 3,
         text: "A dog eating a Pop Tart",
         questionId: 2,
+        gameId: 2,
         imageUrl: "LINK TO IMAGE",
       },
       {
@@ -49,6 +50,7 @@ describe("createVoteMap", () => {
         userId: 4,
         text: "A dog eating a burger",
         questionId: 2,
+        gameId: 2,
         imageUrl: "LINK TO IMAGE",
       },
     ];


### PR DESCRIPTION
## Changes 🔐 
1. Restrict the number of regenerations a user can have for a game to 3
2. Store generations in localStorage so that they still appear on refresh of the page within the `prompt.tsx` component