### PR TITLE
Feat: Mobile Edits and Face Off Result Ties

### DIFF
--- a/client/TODO.md
+++ b/client/TODO.md
@@ -10,7 +10,16 @@
 
 ## In Progress
 
-- [ ] Maximum on amount of regenerations (3 per game?)
+- [ ] Trying new prompt should not erase original prompt
+- [ ] Show face off result without scrolling
+- [ ] Confim vote (and other buttons) be fixed to bottom of page
+- [ ] Green color for confirm vote button?
+- [ ] Try Replicate AI for image generation (so that we can have actors and naughty stuff)
+- [ ] +1000 instead of 1000+ for point results
+- [ ] Random generated image option
+- [ ] Music/Sound effects
+- [ ] Prompt tutorial
+- [ ] Show point progress during round changes
 
 ## Done ✓
 
@@ -29,3 +38,4 @@
 - [x] Change image generator endpoint to use `openai-edge`
 - [x] How-to-play screen
 - [x] Add donate button
+- [x] Maximum on amount of regenerations (3 per game?)

--- a/client/TODO.md
+++ b/client/TODO.md
@@ -10,12 +10,8 @@
 
 ## In Progress
 
-- [ ] Trying new prompt should not erase original prompt
-- [ ] Show face off result without scrolling
-- [ ] Confim vote (and other buttons) be fixed to bottom of page
 - [ ] Green color for confirm vote button?
 - [ ] Try Replicate AI for image generation (so that we can have actors and naughty stuff)
-- [ ] +1000 instead of 1000+ for point results
 - [ ] Random generated image option
 - [ ] Music/Sound effects
 - [ ] Prompt tutorial
@@ -39,3 +35,7 @@
 - [x] How-to-play screen
 - [x] Add donate button
 - [x] Maximum on amount of regenerations (3 per game?)
+- [x] +1000 instead of 1000+ for point results
+- [x] Confim vote (and other buttons) be fixed to bottom of page
+- [x] Show face off result without scrolling
+- [x] Trying new prompt should not erase original prompt

--- a/client/src/app/room/[code]/game/game.tsx
+++ b/client/src/app/room/[code]/game/game.tsx
@@ -49,12 +49,12 @@ export default function Game({ roomCode, gameInfo }: GameProps) {
 
   // Store players who have submitted their prompts for a round
   const [submittedPlayerIds, setSubmittedPlayerIds] = useState<Set<number>>(
-    new Set(gameInfo.submittedPlayers)
+    new Set(gameInfo.submittedPlayers),
   );
 
   // Store players who have submitted votes for the current question
   const [votedPlayers, setVotedPlayers] = useState<UserVote[]>(
-    gameInfo.votedPlayers
+    gameInfo.votedPlayers,
   );
 
   // Persisted state from server for state machine
@@ -96,7 +96,7 @@ export default function Game({ roomCode, gameInfo }: GameProps) {
       console.log("[RECEIVED EVENT]", event);
       send(event);
     },
-    [send]
+    [send],
   );
 
   // Update which players have submitted their generations
@@ -115,7 +115,7 @@ export default function Game({ roomCode, gameInfo }: GameProps) {
         !!gameId &&
         !!round &&
         (state.matches("faceOff") || state.matches("faceOffResults")),
-    }
+    },
   );
   const { data: leaderboard, isLoading: leaderboardLoading } = useQuery(
     ["leaderboard", "gameId", gameId],
@@ -126,7 +126,7 @@ export default function Game({ roomCode, gameInfo }: GameProps) {
         (state.matches("winnerLeadUp") ||
           state.matches("winner") ||
           state.matches("leaderboard")),
-    }
+    },
   );
 
   const currFaceOffQuestion =
@@ -184,7 +184,7 @@ export default function Game({ roomCode, gameInfo }: GameProps) {
       submittedPlayerIds,
       currFaceOffQuestion,
       votedPlayers,
-      leaderboard
+      leaderboard,
     );
   }, [
     gameInfo,
@@ -206,7 +206,7 @@ export default function Game({ roomCode, gameInfo }: GameProps) {
     <main
       className={cn(
         !state.matches("leaderboard") &&
-          "flex min-h-[100dvh] flex-col justify-center"
+          "flex min-h-[100dvh] flex-col justify-center",
       )}
     >
       <section className="container mx-auto px-4 py-16">

--- a/client/src/components/button.tsx
+++ b/client/src/components/button.tsx
@@ -7,54 +7,54 @@ const Button = (props: ButtonHTMLAttributes<HTMLButtonElement>) => {
     <button
       {...props}
       className={cn(
-        `rounded-md bg-indigo-600 px-4 py-1 text-white transition hover:bg-indigo-500 active:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50 ${
+        `rounded-md bg-indigo-600 px-4 py-1 text-white transition hover:bg-indigo-500 active:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-75 ${
           props.className ?? ""
-        }`
+        }`,
       )}
     />
   );
 };
 
 export const SecondaryButton = (
-  props: ButtonHTMLAttributes<HTMLButtonElement>
+  props: ButtonHTMLAttributes<HTMLButtonElement>,
 ) => {
   return (
     <button
       {...props}
       className={cn(
-        `rounded-md bg-gray-300 px-4 py-1 text-black transition hover:bg-gray-200 active:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-50 ${
+        `rounded-md bg-gray-300 px-4 py-1 text-black transition hover:bg-gray-200 active:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-75 ${
           props.className ?? ""
-        }`
+        }`,
       )}
     />
   );
 };
 
 export const LinkButton = (
-  props: LinkProps & LinkHTMLAttributes<HTMLAnchorElement>
+  props: LinkProps & LinkHTMLAttributes<HTMLAnchorElement>,
 ) => {
   return (
     <Link
       {...props}
       className={cn(
-        `rounded-md bg-indigo-600 px-4 py-1 text-white transition hover:bg-indigo-500 active:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50 ${
+        `rounded-md bg-indigo-600 px-4 py-1 text-white transition hover:bg-indigo-500 active:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-75 ${
           props.className ?? ""
-        }`
+        }`,
       )}
     />
   );
 };
 
 export const LinkSecondaryButton = (
-  props: LinkProps & LinkHTMLAttributes<HTMLAnchorElement>
+  props: LinkProps & LinkHTMLAttributes<HTMLAnchorElement>,
 ) => {
   return (
     <Link
       {...props}
       className={cn(
-        `rounded-md bg-gray-300 px-4 py-1 text-black transition hover:bg-gray-200 active:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-50 ${
+        `rounded-md bg-gray-300 px-4 py-1 text-black transition hover:bg-gray-200 active:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-75 ${
           props.className ?? ""
-        }`
+        }`,
       )}
     />
   );

--- a/client/src/components/game/connection-established.tsx
+++ b/client/src/components/game/connection-established.tsx
@@ -4,7 +4,7 @@ const ConnectionEstablished = () => {
   return (
     <div className="mx-auto w-fit">
       <h2 className="text-lg md:text-4xl">
-        <TypewriterText>Beginning AI training sequence...</TypewriterText>
+        <TypewriterText>Beginning training sequence...</TypewriterText>
       </h2>
     </div>
   );

--- a/client/src/components/game/face-off-result-image.tsx
+++ b/client/src/components/game/face-off-result-image.tsx
@@ -182,7 +182,7 @@ const FaceOffResultImage = ({
         variants={pointVariants}
         className="absolute -top-8 left-0 right-0 z-0 text-center"
       >
-        <motion.span>{animatedPoints}</motion.span>+
+        +<motion.span>{animatedPoints}</motion.span>
       </motion.p>
       <motion.ul
         initial={false}

--- a/client/src/components/game/face-off-result-image.tsx
+++ b/client/src/components/game/face-off-result-image.tsx
@@ -174,7 +174,7 @@ const FaceOffResultImage = ({
       }
       variants={imageVariants}
       transition={{ when: "beforeChildren" }}
-      className="relative"
+      className="relative w-full"
     >
       <motion.p
         initial={false}
@@ -193,11 +193,11 @@ const FaceOffResultImage = ({
         {votes.map((vote, i) => (
           <motion.li
             key={i}
-            className="absolute inline-block rounded-md bg-indigo-300 p-4 shadow-md"
+            className="absolute inline-block rounded-md bg-indigo-300 p-2 shadow-md md:p-4"
             variants={voteItemVariants}
             style={shuffledVotePositions[i]}
           >
-            <p className="text-sm text-black">{vote}</p>
+            <p className="text-xs text-black md:text-sm">{vote}</p>
           </motion.li>
         ))}
       </motion.ul>
@@ -236,34 +236,34 @@ const FaceOffResultImage = ({
       >
         <AnimatePresence>
           {(isWinner || isLoser || isTie) && (
-            <motion.p
-              key="prompt"
-              initial={{ opacity: 0, y: -25 }}
-              animate={{
-                opacity: 1,
-                y: 0,
-              }}
-              className="mb-4"
-            >
-              {prompt}
-            </motion.p>
-          )}
-          {(isWinner || isLoser || isTie) && (
             <motion.div
               key="nickname"
               initial={{ opacity: 0, y: -25 }}
               animate={{
                 opacity: 1,
                 y: 0,
-                transition: { delay: 0.5 },
               }}
-              className="flex justify-between"
+              className="mb-2 flex justify-between"
             >
               <h3 className="text-lg text-indigo-700 dark:text-indigo-300">
                 {nickname}
               </h3>{" "}
               <p>{percentage.toLocaleString()}%</p>
             </motion.div>
+          )}
+          {(isWinner || isLoser || isTie) && (
+            <motion.p
+              key="prompt"
+              className="w-full text-sm md:text-base"
+              initial={{ opacity: 0, y: -25 }}
+              animate={{
+                opacity: 1,
+                y: 0,
+                transition: { delay: 0.5 },
+              }}
+            >
+              {prompt}
+            </motion.p>
           )}
         </AnimatePresence>
       </motion.figcaption>

--- a/client/src/components/game/face-off-result-image.tsx
+++ b/client/src/components/game/face-off-result-image.tsx
@@ -57,6 +57,13 @@ const captionVariants: Variants = {
       delayChildren: 2.5,
     },
   },
+  tie: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      delayChildren: 1,
+    },
+  },
 };
 
 const voteVariants: Variants = {
@@ -128,7 +135,7 @@ const FaceOffResultImage = ({
   showLoser: boolean;
   showVotes: boolean;
   showPoints: boolean;
-  winningImage: 1 | 2;
+  winningImage: 1 | 2 | null;
   votes: string[];
   pointIncrease: number;
   setShowImage: Dispatch<SetStateAction<boolean>>;
@@ -150,6 +157,7 @@ const FaceOffResultImage = ({
 
   const isWinner = winningImage === id && showWinner;
   const isLoser = winningImage !== id && showLoser;
+  const isTie = winningImage === null && showWinner;
 
   return (
     <motion.figure
@@ -197,8 +205,11 @@ const FaceOffResultImage = ({
         className={cn(
           `aspect-square transform rounded-xl filter transition`,
           isWinner && "ring ring-yellow-600",
-          winningImage !== id && showWinner && "grayscale filter", // do black+white transition immediately when winner is shown
-          showVotes && "brightness-50"
+          winningImage !== id &&
+            winningImage !== null &&
+            showWinner &&
+            "grayscale filter", // do black+white transition immediately when winner is shown
+          showVotes && "brightness-50",
         )}
         src={image}
         alt={`OpenAI Image with the prompt: ${prompt}`}
@@ -209,7 +220,7 @@ const FaceOffResultImage = ({
       <div
         className={cn(
           "absolute -right-2 -top-2 scale-0 transform rounded-full bg-yellow-600 p-2 text-xl text-white opacity-0 transition",
-          isWinner && "scale-100 opacity-100"
+          isWinner && "scale-100 opacity-100",
         )}
       >
         <BsTrophy />
@@ -217,12 +228,14 @@ const FaceOffResultImage = ({
       <motion.figcaption
         layout="position"
         initial={false}
-        animate={isWinner ? "winner" : isLoser ? "loser" : "hidden"}
+        animate={
+          isTie ? "tie" : isWinner ? "winner" : isLoser ? "loser" : "hidden"
+        }
         variants={captionVariants}
         className="py-4"
       >
         <AnimatePresence>
-          {(isWinner || isLoser) && (
+          {(isWinner || isLoser || isTie) && (
             <motion.p
               key="prompt"
               initial={{ opacity: 0, y: -25 }}
@@ -235,7 +248,7 @@ const FaceOffResultImage = ({
               {prompt}
             </motion.p>
           )}
-          {(isWinner || isLoser) && (
+          {(isWinner || isLoser || isTie) && (
             <motion.div
               key="nickname"
               initial={{ opacity: 0, y: -25 }}

--- a/client/src/components/game/face-off-result.tsx
+++ b/client/src/components/game/face-off-result.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { EventFrom, StateFrom } from "xstate";
 
 import {
@@ -47,20 +47,24 @@ const FaceOffResult = ({
 
       return acc;
     },
-    { player1Votes: [], player2Votes: [] }
+    { player1Votes: [], player2Votes: [] },
   );
 
   const pointsPerOnePercent = 10;
 
   const image1VotePercentage =
-    Math.round(voteMap.player1Votes.length / votedPlayers.length) * 100;
+    (voteMap.player1Votes.length / votedPlayers.length) * 100;
   const image1Points = image1VotePercentage * pointsPerOnePercent;
   const image2VotePercentage =
-    Math.round(voteMap.player2Votes.length / votedPlayers.length) * 100;
+    (voteMap.player2Votes.length / votedPlayers.length) * 100;
   const image2Points = image2VotePercentage * pointsPerOnePercent;
 
-  const winningImage: 1 | 2 =
-    voteMap.player1Votes.length > voteMap.player2Votes.length ? 1 : 2;
+  const winningImage: 1 | 2 | null =
+    voteMap.player1Votes.length > voteMap.player2Votes.length
+      ? 1
+      : voteMap.player1Votes.length < voteMap.player2Votes.length
+      ? 2
+      : null;
 
   const [showImage1, setShowImage1] = useState(false);
   const [showImage2, setShowImage2] = useState(false);
@@ -117,8 +121,23 @@ const FaceOffResult = ({
       </div>
       <motion.div
         layout="position"
-        className="mb-16 flex flex-col md:flex-row gap-y-4 gap-x-6"
+        className="relative mb-16 flex flex-col gap-x-6 gap-y-4 md:flex-row"
       >
+        <AnimatePresence>
+          {image1Points === image2Points && showWinner && (
+            <motion.div className="absolute -top-12 left-1/2 -translate-x-1/2 text-center">
+              <motion.h3
+                className="text-lg"
+                initial={{ opacity: 0, scale: 0 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0 }}
+              >
+                Tie!
+              </motion.h3>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
         <FaceOffResultImage
           id={1}
           prompt={image1.text}
@@ -132,7 +151,7 @@ const FaceOffResult = ({
           showPoints={showPoints}
           winningImage={winningImage}
           votes={voteMap.player1Votes.map(
-            (votedPlayer) => votedPlayer.user.nickname
+            (votedPlayer) => votedPlayer.user.nickname,
           )}
           pointIncrease={image1Points}
           setShowImage={setShowImage1}
@@ -150,7 +169,7 @@ const FaceOffResult = ({
           showPoints={showPoints}
           winningImage={winningImage}
           votes={voteMap.player2Votes.map(
-            (votedPlayer) => votedPlayer.user.nickname
+            (votedPlayer) => votedPlayer.user.nickname,
           )}
           pointIncrease={image2Points}
           setShowImage={setShowImage2}

--- a/client/src/components/game/face-off-result.tsx
+++ b/client/src/components/game/face-off-result.tsx
@@ -109,7 +109,7 @@ const FaceOffResult = ({
 
   return (
     <div className="mx-auto max-w-2xl">
-      <div className="relative mb-14">
+      <div className="relative mb-20">
         <motion.h2
           initial={{ y: 10, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
@@ -119,10 +119,7 @@ const FaceOffResult = ({
           {currQuestionGenerations.question.text}
         </motion.h2>
       </div>
-      <motion.div
-        layout="position"
-        className="relative mb-16 flex flex-col gap-x-6 gap-y-4 md:flex-row"
-      >
+      <motion.div layout="position" className="relative mb-16 flex gap-6">
         <AnimatePresence>
           {image1Points === image2Points && showWinner && (
             <motion.div className="absolute -top-12 left-1/2 -translate-x-1/2 text-center">

--- a/client/src/components/game/face-off.tsx
+++ b/client/src/components/game/face-off.tsx
@@ -4,9 +4,7 @@ import { useContext, useState } from "react";
 import { motion } from "framer-motion";
 import { EventFrom, StateFrom } from "xstate";
 
-import SadDog from "@ai/images/sad-dog.webp";
-import SadDog2 from "@ai/images/sad-dog-2.webp";
-import Button from "@ai/components/button";
+import Button, { SecondaryButton } from "@ai/components/button";
 import ImageChoice, { ImageOption } from "./image-choice";
 import Ellipsis from "@ai/components/ellipsis";
 import Timer from "./timer";
@@ -88,14 +86,29 @@ const FaceOff = ({
           />
           <div className="mt-8">
             {currUserInFaceOff || voteSubmitted ? (
-              <p>Waiting for other AI trainers to finish voting...</p>
+              <>
+                <div className="fixed bottom-4 left-0 right-0 mx-auto w-full max-w-2xl px-6 md:hidden">
+                  <SecondaryButton
+                    className="w-full shadow-lg disabled:opacity-100"
+                    disabled
+                  >
+                    Waiting for other trainers to finish voting...
+                  </SecondaryButton>
+                </div>
+                <p className="hidden md:block">
+                  Waiting for other trainers to finish voting...
+                </p>
+              </>
             ) : (
-              <Button
-                onClick={onImageChoice}
-                disabled={!selectedImage || loading}
-              >
-                {!loading ? "Confirm Vote" : <Ellipsis />}
-              </Button>
+              <div className="fixed bottom-4 left-0 right-0 mx-auto w-full max-w-2xl px-6 md:static md:px-0">
+                <Button
+                  className="w-full shadow-lg md:w-auto"
+                  onClick={onImageChoice}
+                  disabled={!selectedImage || loading}
+                >
+                  {!loading ? "Confirm Vote" : <Ellipsis />}
+                </Button>
+              </div>
             )}
           </div>
         </>

--- a/client/src/components/game/image-choice.tsx
+++ b/client/src/components/game/image-choice.tsx
@@ -59,8 +59,8 @@ const ImageChoiceOption = ({
         />
         <FiCheck
           className={cn(
-            "absolute -right-2 -top-2 scale-0 transform rounded-full bg-green-600 p-0.5 text-xl text-white transition",
-            selectedImage === option && "scale-100"
+            "absolute -right-2 -top-2 scale-0 transform rounded-full bg-green-600 p-0.5 text-3xl text-white transition",
+            selectedImage === option && "scale-100",
           )}
         />
       </button>
@@ -114,7 +114,7 @@ const ImageChoice = ({
   };
 
   return (
-    <div className="flex flex-col md:flex-row gap-6">
+    <div className="flex flex-col gap-6 md:flex-row">
       {imageOption1.src && (
         <ImageChoiceOption
           image={imageOption1}

--- a/client/src/components/game/prompt.tsx
+++ b/client/src/components/game/prompt.tsx
@@ -62,7 +62,7 @@ const Prompt = ({
         }),
       {
         enabled: !!gameId && !!userId,
-      }
+      },
     );
 
   const incrementRegenerationCountMutation = useMutation({
@@ -98,13 +98,13 @@ const Prompt = ({
 
   const [loading, setLoading] = useState(false);
   const [imagePrompt, setImagePrompt] = useState(
-    window.localStorage.getItem("prompt") ?? ""
+    window.localStorage.getItem("prompt") ?? "",
   );
   const [imageOption1, setImageOption1] = useState(
-    window.localStorage.getItem("image1") ?? ""
+    window.localStorage.getItem("image1") ?? "",
   );
   const [imageOption2, setImageOption2] = useState(
-    window.localStorage.getItem("image2") ?? ""
+    window.localStorage.getItem("image2") ?? "",
   );
   const [selectedImage, setSelectedImage] = useState<ImageOption>();
 
@@ -133,19 +133,22 @@ const Prompt = ({
     setLoading(false);
   };
 
-  const resetImageAndPrompt = () => {
+  const resetPrompt = () => {
     setImagePrompt("");
+    window.localStorage.removeItem("prompt");
+  };
+
+  const resetImage = () => {
     setImageOption1("");
     setImageOption2("");
     setSelectedImage(undefined);
-    window.localStorage.removeItem("prompt");
     window.localStorage.removeItem("image1");
     window.localStorage.removeItem("image2");
   };
 
   const onTryAnotherPrompt = () => {
     if (userId !== undefined) {
-      resetImageAndPrompt();
+      resetImage();
       incrementRegenerationCountMutation.mutate({ gameId, userId });
       return;
     }
@@ -172,7 +175,8 @@ const Prompt = ({
 
     if (stage === "FIRST") {
       setStage("SECOND");
-      resetImageAndPrompt();
+      resetPrompt();
+      resetImage();
     } else {
       window.localStorage.removeItem("prompt");
       window.localStorage.removeItem("image1");
@@ -247,19 +251,21 @@ const Prompt = ({
         {imagesLoaded && (
           <div className="mt-4">
             <p className="mb-8">{imagePrompt}</p>
-            <div className="flex flex-wrap gap-x-2 gap-y-4">
+            <div className="fixed bottom-4 left-0 right-0 flex w-full gap-x-2 gap-y-4 px-4 md:static md:flex-wrap md:px-0">
               <Button
+                className="w-full shadow-lg"
                 onClick={onImageSubmit}
                 disabled={!selectedImage || loading}
               >
                 {!loading ? "Submit Image" : <Ellipsis />}
               </Button>
               <SecondaryButton
+                className="w-full"
                 onClick={onTryAnotherPrompt}
                 disabled={loading || outOfRegenerations}
               >
                 {!loading ? (
-                  `Try New Prompt ${
+                  `Create New Images ${
                     !regenerationCountLoading &&
                     regenerationCount !== undefined &&
                     typeof regenerationCount?.count === "number" ? (

--- a/client/src/components/game/prompt.tsx
+++ b/client/src/components/game/prompt.tsx
@@ -251,16 +251,16 @@ const Prompt = ({
         {imagesLoaded && (
           <div className="mt-4">
             <p className="mb-8">{imagePrompt}</p>
-            <div className="fixed bottom-4 left-0 right-0 flex w-full gap-x-2 gap-y-4 px-4 md:static md:flex-wrap md:px-0">
+            <div className="fixed bottom-4 left-0 right-0 mx-auto flex w-full max-w-2xl gap-x-2 gap-y-4 px-5 md:static md:px-0">
               <Button
-                className="w-full shadow-lg"
+                className="w-full shadow-lg md:w-auto"
                 onClick={onImageSubmit}
                 disabled={!selectedImage || loading}
               >
                 {!loading ? "Submit Image" : <Ellipsis />}
               </Button>
               <SecondaryButton
-                className="w-full"
+                className="w-full shadow-lg md:w-auto"
                 onClick={onTryAnotherPrompt}
                 disabled={loading || outOfRegenerations}
               >

--- a/client/src/components/game/prompt.tsx
+++ b/client/src/components/game/prompt.tsx
@@ -251,7 +251,7 @@ const Prompt = ({
         {imagesLoaded && (
           <div className="mt-4">
             <p className="mb-8">{imagePrompt}</p>
-            <div className="fixed bottom-4 left-0 right-0 mx-auto flex w-full max-w-2xl gap-x-2 gap-y-4 px-5 md:static md:px-0">
+            <div className="fixed bottom-4 left-0 right-0 mx-auto flex w-full max-w-2xl gap-x-2 gap-y-4 px-6 md:static md:px-0">
               <Button
                 className="w-full shadow-lg md:w-auto"
                 onClick={onImageSubmit}


### PR DESCRIPTION
## Changes 📱 
1. Add TODOs from test playthrough
2. Increase opacity for disabled buttons
3. Remove mention of AI
4. Handle ties for face-off result screen and show animation
5. Place face-off result images back in a row
6. Switch placement of result prompt and user/percentage
7. Don't clear the prompt when creating new images
8. Buttons on mobile for the prompt and voting screens are fixed to the bottom of the screen on mobile