### PR TITLE
Feat: Server Generation Limit

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -13,6 +13,9 @@ const nextConfig = {
       {
         hostname: "replicate.delivery",
       },
+      {
+        hostname: "pbxt.replicate.delivery",
+      },
     ],
   },
 };

--- a/client/src/app/api/replicate/route.ts
+++ b/client/src/app/api/replicate/route.ts
@@ -123,6 +123,10 @@ export async function POST(req: Request) {
       }
     }
 
+    if (imageGenerations) {
+      console.log("Received images:", imageGenerations);
+    }
+
     return NextResponse.json({
       result: imageGenerations ? imageGenerations : "Failed to generate images",
     });

--- a/client/src/app/room/[code]/game/game.tsx
+++ b/client/src/app/room/[code]/game/game.tsx
@@ -80,14 +80,17 @@ export default function Game({ roomCode, gameInfo }: GameProps) {
 
   // Send updated state to server
   const handleStateChange = useCallback(() => {
-    socket.emit("clientEvent", {
-      state: JSON.stringify(state),
-      gameId: gameInfo.game.id,
-      round: state.context.round,
-      completedAt: state.matches("leaderboard")
-        ? new Date().toISOString()
-        : undefined,
-    });
+    // Don't send state change to backend if it is a `promptSubmitted` state
+    if (!state.matches("promptSubmitted")) {
+      socket.emit("clientEvent", {
+        state: JSON.stringify(state),
+        gameId: gameInfo.game.id,
+        round: state.context.round,
+        completedAt: state.matches("leaderboard")
+          ? new Date().toISOString()
+          : undefined,
+      });
+    }
   }, [gameInfo.game.id, socket, state]);
 
   // Receive state changes from server

--- a/client/src/app/server-actions.ts
+++ b/client/src/app/server-actions.ts
@@ -31,6 +31,7 @@ export type Generation = {
   userId: number;
   questionId: number;
   gameId: number;
+  selected: boolean;
   createdAt: string;
 };
 export type Question = {
@@ -52,11 +53,26 @@ export type Vote = {
 
 export type UserVote = { vote: Vote; user: User };
 
+export type GameRoundGeneration = {
+  generation: Generation;
+  question: {
+    id: number;
+    text: string;
+    round: number;
+    gameId: number;
+    player1: number;
+    player2: number;
+    createdAt: Date;
+  };
+  user: User;
+};
+
 export type GameInfo = {
   hostId: number | null;
   game: Game;
   players: User[];
   questions: Question[];
+  gameRoundGenerations: GameRoundGeneration[];
   submittedPlayers: number[];
   votedPlayers: UserVote[];
 };
@@ -89,6 +105,10 @@ export async function createHost(nickname: string) {
     }),
   });
 
+  if (!response.ok) {
+    throw new Error("Failed to create host and room");
+  }
+
   const data: CreateHostResponse = await response.json();
 
   return data;
@@ -108,6 +128,10 @@ export async function existingHost(userId: number) {
       userId,
     }),
   });
+
+  if (!response.ok) {
+    throw new Error("Failed to create room for existing host");
+  }
 
   const data: ExistingHostResponse = await response.json();
 
@@ -149,6 +173,10 @@ export type GetRoomInfoResponse = RoomInfo | ErrorResponse;
 export async function getRoomInfo(code: string) {
   const response = await fetch(`${URL}/room/${code}`, { cache: "no-store" });
 
+  if (!response.ok) {
+    throw new Error("Failed to obtain room info");
+  }
+
   const data: GetRoomInfoResponse = await response.json();
 
   return data;
@@ -160,6 +188,10 @@ export type GetGameInfoResponse = GameInfo | ErrorResponse;
 
 export async function getGameInfo(code: string) {
   const response = await fetch(`${URL}/game/${code}`, { cache: "no-store" });
+
+  if (!response.ok) {
+    throw new Error("Failed to obtain game info");
+  }
 
   const data: GetGameInfoResponse = await response.json();
 
@@ -177,63 +209,46 @@ export async function getLeaderboardById({ gameId }: { gameId: number }) {
     cache: "no-store",
   });
 
+  if (!response.ok) {
+    throw new Error("Failed to obtain leaderboard");
+  }
+
   const data: GetGameLeaderboardResponse = await response.json();
 
   return data;
 }
 
-export type GetRegenerationCountResponse = { count: number };
-
-export async function getRegenerationCount({
-  gameId,
-  userId,
-}: {
-  gameId: number;
-  userId: number;
-}) {
-  const response = await fetch(
-    `${URL}/game/${gameId}/regenerations/${userId}`,
-    {
-      cache: "no-store",
-    },
-  );
-
-  const data: GetRegenerationCountResponse = await response.json();
-
-  return data;
-}
-
-export type incrementUserRegenerationCountResponse = {
-  room: Room;
-};
-
-export async function incrementUserRegenerationCount({
-  gameId,
-  userId,
-}: {
-  gameId: number;
-  userId: number;
-}) {
-  const response = await fetch(
-    `${URL}/game/${gameId}/regenerations/${userId}`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        userId,
-        gameId,
-      }),
-    },
-  );
-
-  const data: incrementUserRegenerationCountResponse = await response.json();
-
-  return data;
-}
-
 // ! ----------> GENERATIONS <----------
+
+export type CreateGenerationsResponse = Generation[];
+
+export async function createGenerations({
+  userId,
+  gameId,
+  questionId,
+  images,
+}: {
+  userId: number;
+  gameId: number;
+  questionId: number;
+  images: { text: string; imageUrl: string }[];
+}) {
+  const response = await fetch(`${URL}/generations`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ userId, gameId, questionId, images }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to create generations");
+  }
+
+  const data: CreateGenerationsResponse = await response.json();
+
+  return data;
+}
 
 export type GetFaceOffsResponse = QuestionGenerations[];
 
@@ -248,6 +263,10 @@ export async function getFaceOffs({
     `${URL}/generations/gameId/${gameId}/round/${round}`,
     { cache: "no-store" },
   );
+
+  if (!response.ok) {
+    throw new Error("Failed to obtain face-offs");
+  }
 
   const data: GetFaceOffsResponse = await response.json();
 

--- a/client/src/components/game/prompt.tsx
+++ b/client/src/components/game/prompt.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { FormEvent, useContext, useMemo, useRef, useState } from "react";
+import {
+  FormEvent,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { EventFrom, StateFrom } from "xstate";
 import toast from "react-hot-toast";
@@ -41,6 +48,7 @@ const Prompt = ({
   const userGameRoundGenerations = gameInfo.gameRoundGenerations.filter(
     (generation) => generation.user.id === userId,
   );
+
   const currRound = state.context.round;
   const maxRegenerations = 3;
 
@@ -163,6 +171,18 @@ const Prompt = ({
 
     setLoading(false);
   };
+
+  useEffect(() => {
+    // Redirect to prompt submitted page if the player already has two images submitted for the round
+    const alreadySubmittedImages =
+      userGameRoundGenerations.filter(
+        (generation) => generation.generation.selected,
+      ).length >= 2;
+
+    if (alreadySubmittedImages) {
+      send({ type: "SUBMIT" });
+    }
+  }, [send, userGameRoundGenerations]);
 
   return (
     <motion.div layout="position" className="max-w-2xl">

--- a/client/src/utils/socket.ts
+++ b/client/src/utils/socket.ts
@@ -27,12 +27,9 @@ export interface ClientToServerEvents {
   initiatePlayAnotherGame: (code: string) => void;
   testEvent: (code: string) => void;
   generationSubmitted: (data: {
+    generationId: number;
     gameId: number;
     round: number;
-    userId: number;
-    questionId: number;
-    text: string;
-    imageUrl: string;
   }) => void;
   voteSubmitted: (data: {
     userId: number;
@@ -49,5 +46,5 @@ export const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(
   URL,
   {
     autoConnect: false,
-  }
+  },
 );

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,5 +1,6 @@
 import { InferModel } from "drizzle-orm";
 import {
+  boolean,
   integer,
   pgTable,
   primaryKey,
@@ -87,6 +88,7 @@ export const generations = pgTable("generations", {
     .notNull(),
   text: text("text").notNull(),
   imageUrl: text("image_url").notNull(),
+  selected: boolean("selected").default(false).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
@@ -111,7 +113,6 @@ export const usersToGames = pgTable(
       .references(() => games.id)
       .notNull(),
     points: integer("points").default(0).notNull(),
-    regenerationCount: integer("regeneration_count").default(0).notNull(),
   },
   (table) => ({
     cpk: primaryKey(table.userId, table.gameId),

--- a/server/drizzle/0018_late_thor.sql
+++ b/server/drizzle/0018_late_thor.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "generations" ADD COLUMN "selected" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "users_to_games" DROP COLUMN IF EXISTS "regeneration_count";

--- a/server/drizzle/meta/0018_snapshot.json
+++ b/server/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,575 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "9ce8536e-8d91-4faa-a444-c62347ed2abc",
+  "prevId": "9036cd8d-8cc3-49fe-8913-9d2d9aca4b6d",
+  "tables": {
+    "games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "room_code": {
+          "name": "room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_room_code_rooms_code_fk": {
+          "name": "games_room_code_rooms_code_fk",
+          "tableFrom": "games",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "generations": {
+      "name": "generations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected": {
+          "name": "selected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "generations_user_id_users_id_fk": {
+          "name": "generations_user_id_users_id_fk",
+          "tableFrom": "generations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "generations_game_id_games_id_fk": {
+          "name": "generations_game_id_games_id_fk",
+          "tableFrom": "generations",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "generations_question_id_questions_id_fk": {
+          "name": "generations_question_id_questions_id_fk",
+          "tableFrom": "generations",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "questions_to_games": {
+      "name": "questions_to_games",
+      "schema": "",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_1": {
+          "name": "player_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_2": {
+          "name": "player_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_to_games_question_id_questions_id_fk": {
+          "name": "questions_to_games_question_id_questions_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "questions_to_games_game_id_games_id_fk": {
+          "name": "questions_to_games_game_id_games_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "questions_to_games_player_1_users_id_fk": {
+          "name": "questions_to_games_player_1_users_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_1"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "questions_to_games_player_2_users_id_fk": {
+          "name": "questions_to_games_player_2_users_id_fk",
+          "tableFrom": "questions_to_games",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "questions_to_games_game_id_question_id": {
+          "name": "questions_to_games_game_id_question_id",
+          "columns": [
+            "game_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rooms_host_id_users_id_fk": {
+          "name": "rooms_host_id_users_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users_to_games": {
+      "name": "users_to_games",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_games_user_id_users_id_fk": {
+          "name": "users_to_games_user_id_users_id_fk",
+          "tableFrom": "users_to_games",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_games_game_id_games_id_fk": {
+          "name": "users_to_games_game_id_games_id_fk",
+          "tableFrom": "users_to_games",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_games_user_id_game_id": {
+          "name": "users_to_games_user_id_game_id",
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "users_to_rooms": {
+      "name": "users_to_rooms",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_code": {
+          "name": "room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_rooms_user_id_users_id_fk": {
+          "name": "users_to_rooms_user_id_users_id_fk",
+          "tableFrom": "users_to_rooms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_rooms_room_code_rooms_code_fk": {
+          "name": "users_to_rooms_room_code_rooms_code_fk",
+          "tableFrom": "users_to_rooms",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_rooms_user_id_room_code": {
+          "name": "users_to_rooms_user_id_room_code",
+          "columns": [
+            "user_id",
+            "room_code"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "votes_generation_id_generations_id_fk": {
+          "name": "votes_generation_id_generations_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "generations",
+          "columnsFrom": [
+            "generation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1691244559328,
       "tag": "0017_nostalgic_northstar",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "5",
+      "when": 1693183820410,
+      "tag": "0018_late_thor",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/controllers/game.controller.ts
+++ b/server/src/controllers/game.controller.ts
@@ -2,8 +2,6 @@ import type { NextFunction, Request, Response } from "express";
 import {
   getLeaderboardById,
   getPageGameInfoByRoomCode,
-  getUserRegenerationCount,
-  incrementUserRegenerationCount,
 } from "../services/game.service";
 
 export async function getPageGameInfoByRoomCodeController(
@@ -45,60 +43,6 @@ export async function getLeaderboardByIdController(
     }
 
     res.status(200).send(leaderboard);
-  } catch (error) {
-    next(error);
-  }
-}
-
-export async function getUserRegenerationCountController(
-  req: Request<{ id: string; userId: string }>,
-  res: Response,
-  next: NextFunction
-) {
-  try {
-    const gameId = Number.parseInt(req.params.id);
-    const userId = Number.parseInt(req.params.userId);
-
-    const regenerationCount = await getUserRegenerationCount({
-      gameId,
-      userId,
-    });
-
-    if (regenerationCount === undefined || regenerationCount === null) {
-      res.status(404).send({
-        error: `Regeneration Count with a game id of ${gameId} and a user id of ${userId} was not found`,
-      });
-      return;
-    }
-
-    res.status(200).send({ count: regenerationCount });
-  } catch (error) {
-    next(error);
-  }
-}
-
-export async function incrementUserRegenerationCountController(
-  req: Request<{ id: string; userId: string }>,
-  res: Response,
-  next: NextFunction
-) {
-  try {
-    const gameId = Number.parseInt(req.params.id);
-    const userId = Number.parseInt(req.params.userId);
-
-    const regenerationCount = await incrementUserRegenerationCount({
-      gameId,
-      userId,
-    });
-
-    if (regenerationCount === undefined || regenerationCount === null) {
-      res.status(404).send({
-        error: `Regeneration Count with a game id of ${gameId} and a user id of ${userId} was not found`,
-      });
-      return;
-    }
-
-    res.status(200).send({ count: regenerationCount });
   } catch (error) {
     next(error);
   }

--- a/server/src/controllers/generation.controller.ts
+++ b/server/src/controllers/generation.controller.ts
@@ -30,7 +30,7 @@ export async function createGenerationsController(
       questionId,
     });
 
-    if (generationCount >= 6) {
+    if (generationCount >= 8) {
       throw new Error("Exceeded generation count for question.");
     }
 
@@ -46,7 +46,7 @@ export async function createGenerationsController(
       )
     );
 
-    return generations;
+    res.status(200).send(generations);
   } catch (error) {
     next(error);
   }

--- a/server/src/controllers/generation.controller.ts
+++ b/server/src/controllers/generation.controller.ts
@@ -1,8 +1,56 @@
 import type { NextFunction, Request, Response } from "express";
 import {
-  getGameRoundGenerations,
+  createGeneration,
+  getFaceOffGenerations,
+  getGenerationCount,
+  getUserGenerationInfo,
   mapGenerationsByQuestion,
 } from "../services/generation.service";
+
+export async function createGenerationsController(
+  req: Request<
+    {},
+    {},
+    {
+      userId: number;
+      gameId: number;
+      questionId: number;
+      images: { text: string; imageUrl: string }[];
+    }
+  >,
+  res: Response,
+  next: NextFunction
+) {
+  try {
+    const { userId, gameId, questionId, images } = req.body;
+
+    const generationCount = await getGenerationCount({
+      gameId,
+      userId,
+      questionId,
+    });
+
+    if (generationCount >= 6) {
+      throw new Error("Exceeded generation count for question.");
+    }
+
+    const generations = await Promise.all(
+      images.map((image) =>
+        createGeneration({
+          userId,
+          gameId,
+          questionId,
+          text: image.text,
+          imageUrl: image.imageUrl,
+        })
+      )
+    );
+
+    return generations;
+  } catch (error) {
+    next(error);
+  }
+}
 
 export async function getFaceOffsController(
   req: Request<{ gameId: string; round: string }>,
@@ -13,12 +61,12 @@ export async function getFaceOffsController(
     const gameId = Number.parseInt(req.params.gameId);
     const round = Number.parseInt(req.params.round);
 
-    const gameRoundGenerations = await getGameRoundGenerations({
+    const faceOffGenerations = await getFaceOffGenerations({
       gameId,
       round,
     });
 
-    if (!gameRoundGenerations) {
+    if (!faceOffGenerations) {
       res.status(404).send({
         error: `Generations with gameId of ${gameId} and round of ${round} were not found`,
       });
@@ -26,10 +74,43 @@ export async function getFaceOffsController(
     }
 
     const faceOffs = mapGenerationsByQuestion({
-      gameRoundGenerations,
+      faceOffGenerations,
     });
 
     res.status(200).send(faceOffs);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getUserGenerationInfoController(
+  req: Request<{
+    gameId: string;
+    userId: string;
+    round: string;
+  }>,
+  res: Response,
+  next: NextFunction
+) {
+  try {
+    const gameId = Number.parseInt(req.params.gameId);
+    const userId = Number.parseInt(req.params.userId);
+    const round = Number.parseInt(req.params.round);
+
+    const generationInfo = await getUserGenerationInfo({
+      gameId,
+      userId,
+      round,
+    });
+
+    if (!generationInfo) {
+      res.status(404).send({
+        error: `Generation info with gameId of ${gameId}, round of ${round}, and userId of ${userId} were not found`,
+      });
+      return;
+    }
+
+    res.status(200).send(generationInfo);
   } catch (error) {
     next(error);
   }

--- a/server/src/handlers/generation.handler.ts
+++ b/server/src/handlers/generation.handler.ts
@@ -3,7 +3,6 @@ import { Server, Socket } from "socket.io";
 import { ClientToServerEvents, ServerToClientEvents } from "../types";
 import { handleSocketError } from "../utils";
 import {
-  createGeneration,
   getFaceOffGenerations,
   getSubmittedPlayers,
   setGenerationAsSubmitted,

--- a/server/src/handlers/generation.handler.ts
+++ b/server/src/handlers/generation.handler.ts
@@ -6,6 +6,7 @@ import {
   createGeneration,
   getFaceOffGenerations,
   getSubmittedPlayers,
+  setGenerationAsSubmitted,
 } from "../services/generation.service";
 import { getGameInfo } from "../services/game.service";
 
@@ -22,7 +23,7 @@ export function generationSocketHandlers(
         return;
       }
 
-      await createGeneration(data);
+      await setGenerationAsSubmitted({ generationId: data.generationId });
 
       const faceOffGenerations = await getFaceOffGenerations({
         gameId: data.gameId,

--- a/server/src/handlers/generation.handler.ts
+++ b/server/src/handlers/generation.handler.ts
@@ -4,7 +4,7 @@ import { ClientToServerEvents, ServerToClientEvents } from "../types";
 import { handleSocketError } from "../utils";
 import {
   createGeneration,
-  getGameRoundGenerations,
+  getFaceOffGenerations,
   getSubmittedPlayers,
 } from "../services/generation.service";
 import { getGameInfo } from "../services/game.service";
@@ -24,12 +24,12 @@ export function generationSocketHandlers(
 
       await createGeneration(data);
 
-      const gameRoundGenerations = await getGameRoundGenerations({
+      const faceOffGenerations = await getFaceOffGenerations({
         gameId: data.gameId,
         round: data.round,
       });
 
-      const submittedUsers = getSubmittedPlayers({ gameRoundGenerations });
+      const submittedUsers = getSubmittedPlayers({ faceOffGenerations });
 
       socket.emit("submittedPlayers", submittedUsers);
       socket
@@ -37,7 +37,7 @@ export function generationSocketHandlers(
         .emit("submittedPlayers", submittedUsers);
 
       const totalNeeded = gameInfo.players.length * 2;
-      const currentAmount = gameRoundGenerations.length;
+      const currentAmount = faceOffGenerations.length;
 
       console.log("[TOTAL NEEDED]", totalNeeded);
 

--- a/server/src/handlers/vote.handler.ts
+++ b/server/src/handlers/vote.handler.ts
@@ -4,8 +4,8 @@ import { ClientToServerEvents, ServerToClientEvents } from "../types";
 import { handleSocketError } from "../utils";
 import { getGameInfo } from "../services/game.service";
 import {
-  getGameRoundGenerations,
-  filterGameRoundGenerationsByQuestionId,
+  getFaceOffGenerations,
+  filterFaceOffGenerationsByQuestionId,
 } from "../services/generation.service";
 import {
   createVote,
@@ -44,14 +44,14 @@ export function voteSocketHandlers(
       const currentAmount = questionVotes.length;
 
       if (currentAmount >= totalNeeded) {
-        const gameRoundGenerations = await getGameRoundGenerations({
+        const faceOffGenerations = await getFaceOffGenerations({
           gameId: data.gameId,
           round: gameInfo.game.round,
         });
 
-        const filteredGenerations = filterGameRoundGenerationsByQuestionId({
+        const filteredGenerations = filterFaceOffGenerationsByQuestionId({
           questionId: data.questionId,
-          gameRoundGenerations,
+          faceOffGenerations,
         });
 
         const voteMap = createVoteMap({

--- a/server/src/routes/game.route.ts
+++ b/server/src/routes/game.route.ts
@@ -2,20 +2,9 @@ import type { Express } from "express";
 import {
   getLeaderboardByIdController,
   getPageGameInfoByRoomCodeController,
-  getUserRegenerationCountController,
-  incrementUserRegenerationCountController,
 } from "../controllers/game.controller";
 
 export function gameRoutes(app: Express) {
   app.get("/game/:code", getPageGameInfoByRoomCodeController);
   app.get("/game/:id/leaderboard", getLeaderboardByIdController);
-  app.get(
-    "/game/:id/regenerations/:userId",
-    getUserRegenerationCountController
-  );
-
-  app.post(
-    "/game/:id/regenerations/:userId",
-    incrementUserRegenerationCountController
-  );
 }

--- a/server/src/routes/generation.route.ts
+++ b/server/src/routes/generation.route.ts
@@ -1,6 +1,16 @@
 import type { Express } from "express";
-import { getFaceOffsController } from "../controllers/generation.controller";
+import {
+  createGenerationsController,
+  getFaceOffsController,
+  getUserGenerationInfoController,
+} from "../controllers/generation.controller";
 
 export function generationRoutes(app: Express) {
+  app.get(
+    "/generations/gameId/:gameId/round/:round/user/:userId",
+    getUserGenerationInfoController
+  );
   app.get("/generations/gameId/:gameId/round/:round", getFaceOffsController);
+
+  app.post("/generations", createGenerationsController);
 }

--- a/server/src/routes/question.route.ts
+++ b/server/src/routes/question.route.ts
@@ -6,7 +6,6 @@ import {
 
 export function questionRoutes(app: Express) {
   app.get("/question/:id", getQuestionByIdController);
-
   app.get(
     "/questions/user/:userId/game/:gameId/round/:round",
     getQuestionsByUserGameRoundController

--- a/server/src/routes/room.route.ts
+++ b/server/src/routes/room.route.ts
@@ -5,7 +5,7 @@ import {
 } from "../controllers/room.controller";
 
 export function roomRoutes(app: Express) {
-  app.post("/room/join", joinRoomController);
-
   app.get("/room/:code", getRoomController);
+
+  app.post("/room/join", joinRoomController);
 }

--- a/server/src/services/generation.service.ts
+++ b/server/src/services/generation.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, sql } from "drizzle-orm";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { db } from "../../db/db";
 import {
   Generation,
@@ -44,7 +44,10 @@ export async function getGameRoundGenerations({
     .where(
       and(eq(generations.gameId, gameId), eq(questionsToGames.round, round))
     )
-    .orderBy(asc(questionsToGames.createdAt), asc(questionsToGames.questionId));
+    .orderBy(
+      desc(questionsToGames.createdAt),
+      desc(questionsToGames.questionId)
+    );
 
   return gameRoundGenerations;
 }
@@ -254,4 +257,18 @@ export async function getUserGenerationInfo({
     );
 
   return generationsForUserForRound;
+}
+
+export async function setGenerationAsSubmitted({
+  generationId,
+}: {
+  generationId: number;
+}) {
+  const updatedGenerations = await db
+    .update(generations)
+    .set({ selected: true })
+    .where(eq(generations.id, generationId))
+    .returning();
+
+  return updatedGenerations[0];
 }

--- a/server/src/services/generation.service.ts
+++ b/server/src/services/generation.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import { db } from "../../db/db";
 import {
   Generation,
@@ -49,13 +49,56 @@ export async function getGameRoundGenerations({
   return gameRoundGenerations;
 }
 
+export async function getFaceOffGenerations({
+  gameId,
+  round,
+}: {
+  gameId: number;
+  round: number;
+}): Promise<GameRoundGeneration[]> {
+  const gameRoundGenerations = await db
+    .select({
+      generation: generations,
+      question: {
+        id: questions.id,
+        text: questions.text,
+        round: questionsToGames.round,
+        gameId: questionsToGames.gameId,
+        player1: questionsToGames.player1,
+        player2: questionsToGames.player2,
+        createdAt: questionsToGames.createdAt,
+      },
+      user: users,
+    })
+    .from(generations)
+    .innerJoin(
+      questionsToGames,
+      and(
+        eq(questionsToGames.gameId, generations.gameId),
+        eq(questionsToGames.questionId, generations.questionId)
+      )
+    )
+    .innerJoin(questions, eq(questions.id, generations.questionId))
+    .innerJoin(users, eq(users.id, generations.userId))
+    .where(
+      and(
+        eq(generations.gameId, gameId),
+        eq(questionsToGames.round, round),
+        eq(generations.selected, true)
+      )
+    )
+    .orderBy(asc(questionsToGames.createdAt), asc(questionsToGames.questionId));
+
+  return gameRoundGenerations;
+}
+
 // TODO: test this function
 export function mapGenerationsByQuestion({
-  gameRoundGenerations,
+  faceOffGenerations,
 }: {
-  gameRoundGenerations: GameRoundGeneration[];
+  faceOffGenerations: GameRoundGeneration[];
 }) {
-  const questionGenerationMap = gameRoundGenerations.reduce<
+  const questionGenerationMap = faceOffGenerations.reduce<
     Record<number, QuestionGenerations>
   >((acc, curr, i) => {
     if (!acc[curr.question.id]) {
@@ -64,19 +107,19 @@ export function mapGenerationsByQuestion({
         player1:
           curr.generation.userId === curr.question.player1
             ? curr.user
-            : gameRoundGenerations[i + 1].user,
+            : faceOffGenerations[i + 1].user,
         player1Generation:
           curr.generation.userId === curr.question.player1
             ? curr.generation
-            : gameRoundGenerations[i + 1].generation, // the generations are ordered by question id so instead of doing a search for the correct generation, we know that it is at the next index
+            : faceOffGenerations[i + 1].generation, // the generations are ordered by question id so instead of doing a search for the correct generation, we know that it is at the next index
         player2:
           curr.generation.userId === curr.question.player2
             ? curr.user
-            : gameRoundGenerations[i + 1].user,
+            : faceOffGenerations[i + 1].user,
         player2Generation:
           curr.generation.userId === curr.question.player2
             ? curr.generation
-            : gameRoundGenerations[i + 1].generation,
+            : faceOffGenerations[i + 1].generation,
       };
     }
 
@@ -90,12 +133,12 @@ export function mapGenerationsByQuestion({
 
 // TODO: Test this function
 export function getSubmittedPlayers({
-  gameRoundGenerations,
+  faceOffGenerations,
 }: {
-  gameRoundGenerations: GameRoundGeneration[];
+  faceOffGenerations: GameRoundGeneration[];
 }) {
   const userGenerationCountMap = new Map<number, number>();
-  const submittedUsers = gameRoundGenerations.reduce<number[]>((acc, curr) => {
+  const submittedUsers = faceOffGenerations.reduce<number[]>((acc, curr) => {
     const currUserId = curr.generation.userId;
 
     if (userGenerationCountMap.get(currUserId) === 1) {
@@ -128,14 +171,14 @@ export async function createGeneration(data: NewGeneration) {
   return newGeneration[0];
 }
 
-export function filterGameRoundGenerationsByQuestionId({
+export function filterFaceOffGenerationsByQuestionId({
   questionId,
-  gameRoundGenerations,
+  faceOffGenerations,
 }: {
   questionId: number;
-  gameRoundGenerations: GameRoundGeneration[];
+  faceOffGenerations: GameRoundGeneration[];
 }) {
-  const filteredGenerations = gameRoundGenerations.reduce<Generation[]>(
+  const filteredGenerations = faceOffGenerations.reduce<Generation[]>(
     (acc, curr) => {
       if (curr.question.id === questionId) {
         acc.push(curr.generation);
@@ -147,4 +190,68 @@ export function filterGameRoundGenerationsByQuestionId({
   );
 
   return filteredGenerations;
+}
+
+export async function getGenerationCount({
+  gameId,
+  userId,
+  questionId,
+}: {
+  gameId: number;
+  userId: number;
+  questionId: number;
+}) {
+  const generationCount = await db
+    .select({
+      count: sql<number>`count(${generations.id})::int`,
+    })
+    .from(generations)
+    .where(
+      and(
+        eq(generations.gameId, gameId),
+        eq(generations.userId, userId),
+        eq(generations.questionId, questionId)
+      )
+    );
+
+  return generationCount[0].count;
+}
+
+export async function getUserGenerationInfo({
+  gameId,
+  userId,
+  round,
+}: {
+  gameId: number;
+  userId: number;
+  round: number;
+}) {
+  const generationsForUserForRound = await db
+    .select({
+      id: generations.id,
+      gameId: generations.gameId,
+      imageUrl: generations.imageUrl,
+      questionId: generations.questionId,
+      selected: generations.selected,
+      text: generations.text,
+      userId: generations.userId,
+      createdAt: generations.createdAt,
+    })
+    .from(generations)
+    .innerJoin(
+      questionsToGames,
+      and(
+        eq(generations.gameId, questionsToGames.gameId),
+        eq(generations.questionId, questionsToGames.questionId)
+      )
+    )
+    .where(
+      and(
+        eq(generations.gameId, gameId),
+        eq(generations.userId, userId),
+        eq(questionsToGames.round, round)
+      )
+    );
+
+  return generationsForUserForRound;
 }

--- a/server/src/tests/generation.test.ts
+++ b/server/src/tests/generation.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "@jest/globals";
-import { filterGameRoundGenerationsByQuestionId } from "../services/generation.service";
+import { filterFaceOffGenerationsByQuestionId } from "../services/generation.service";
 import { GameRoundGeneration } from "../types";
 
 describe("filterGameRoundGenerationsByQuestionId", () => {
   test("expects the filtered array to not have any generations from other questions", () => {
     const testQuestionId = 2;
 
-    const gameRoundGenerations: GameRoundGeneration[] = [
+    const faceOffGenerations: GameRoundGeneration[] = [
       {
         generation: {
           id: 2,
@@ -16,6 +16,7 @@ describe("filterGameRoundGenerationsByQuestionId", () => {
           questionId: 2,
           gameId: 2,
           imageUrl: "LINK TO IMAGE",
+          selected: true,
         },
         question: {
           id: 2,
@@ -41,6 +42,7 @@ describe("filterGameRoundGenerationsByQuestionId", () => {
           questionId: 2,
           gameId: 2,
           imageUrl: "LINK TO IMAGE",
+          selected: true,
         },
         question: {
           id: 2,
@@ -66,6 +68,7 @@ describe("filterGameRoundGenerationsByQuestionId", () => {
           questionId: 2,
           gameId: 2,
           imageUrl: "LINK TO IMAGE",
+          selected: true,
         },
         question: {
           id: 3,
@@ -91,6 +94,7 @@ describe("filterGameRoundGenerationsByQuestionId", () => {
           questionId: 2,
           gameId: 2,
           imageUrl: "LINK TO IMAGE",
+          selected: true,
         },
         question: {
           id: 3,
@@ -109,9 +113,9 @@ describe("filterGameRoundGenerationsByQuestionId", () => {
       },
     ];
 
-    const filteredGenerations = filterGameRoundGenerationsByQuestionId({
+    const filteredGenerations = filterFaceOffGenerationsByQuestionId({
       questionId: testQuestionId,
-      gameRoundGenerations,
+      faceOffGenerations,
     });
 
     expect(filteredGenerations.length).toBe(2);

--- a/server/src/tests/vote.test.ts
+++ b/server/src/tests/vote.test.ts
@@ -43,6 +43,7 @@ describe("createVoteMap", () => {
         questionId: 2,
         gameId: 2,
         imageUrl: "LINK TO IMAGE",
+        selected: true,
       },
       {
         id: 2,
@@ -52,6 +53,7 @@ describe("createVoteMap", () => {
         questionId: 2,
         gameId: 2,
         imageUrl: "LINK TO IMAGE",
+        selected: true,
       },
     ];
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -34,12 +34,9 @@ export interface ClientToServerEvents {
   }) => void;
   testEvent: (code: string) => void;
   generationSubmitted: (data: {
+    generationId: number;
     gameId: number;
     round: number;
-    userId: number;
-    questionId: number;
-    text: string;
-    imageUrl: string;
   }) => void;
   voteSubmitted: (data: {
     userId: number;


### PR DESCRIPTION
## Changes
1. Persist all generations created in the database so that there is no longer a reliance on localStorage to persist previous generations on reload.
2. Fix bug where a player who has submitted all of their needed images for a round makes it so that the other players can skip to the submitted page if they reload their page.
3. Switch image generator for testing to be Stable Diffusion XL.