### PR TITLE
Feat: Add Server Sourcemaps to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,5 @@ jobs:
         run: pnpm test
 
       - name: 🆙 Upload sourcemaps
-        run: npx sentry-cli sourcemaps inject ./apps/server/dist && sentry-cli sourcemaps upload ./apps/server/dist
+        working-directory: "./apps/server"
+        run: pnpm sentry:sourcemaps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2
         with:
-          version: 6.32.2
+          version: 8
 
       - name: 🏗 Setup Node.js environment
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,3 @@ jobs:
 
       - name: 🧪 Test
         run: pnpm test
-
-      - name: 🆙 Upload sourcemaps
-        working-directory: "./apps/server"
-        run: pnpm sentry:sourcemaps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
     steps:
       - name: 🏗 Check out code
@@ -50,3 +53,6 @@ jobs:
 
       - name: 🧪 Test
         run: pnpm test
+
+      - name: 🆙 Upload sourcemaps
+        run: npx sentry-cli sourcemaps inject ./apps/server/dist && sentry-cli sourcemaps upload ./apps/server/dist

--- a/.github/workflows/prod-db-migrate.yml
+++ b/.github/workflows/prod-db-migrate.yml
@@ -19,6 +19,9 @@ jobs:
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
     steps:
       - name: 🏗 Check out code
@@ -26,9 +29,9 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2
         with:
-          version: 6.32.2
+          version: 8
 
       - name: 🏗 Setup Node.js environment
         uses: actions/setup-node@v3

--- a/.github/workflows/upload-server-sourcemaps.yml
+++ b/.github/workflows/upload-server-sourcemaps.yml
@@ -1,18 +1,18 @@
-name: Run Development Database Migrations
+name: Upload Server Sourcemaps
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["main", "dev"]
 
 jobs:
   build:
-    name: Build and Run Migrations
+    name: Build and Upload Server Sourcemaps to Sentry.io
     timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
       POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
       NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
       NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
@@ -42,9 +42,6 @@ jobs:
       - name: 👷 Install dependencies
         run: pnpm install
 
-      # - name: 📀 Install Playwright Browsers
-      #   run: npx playwright install --with-deps
-
-      - name: 🥾 Run db migrations
-        working-directory: "./packages/database"
-        run: pnpm db:migrate:run
+      - name: 🆙 Upload sourcemaps
+        working-directory: "./apps/server"
+        run: pnpm sourcemaps


### PR DESCRIPTION
Closes #38 

## Changes
1. Automatically upload server sourcemaps to CI on push to `main` or `dev`